### PR TITLE
S-515: JCTools works for renaissance apache spark

### DIFF
--- a/jctools-core/src/main/java/org/jctools/util/UnsafeRefArrayAccess.java
+++ b/jctools-core/src/main/java/org/jctools/util/UnsafeRefArrayAccess.java
@@ -32,6 +32,10 @@ public final class UnsafeRefArrayAccess
         {
             REF_ELEMENT_SHIFT = 3;
         }
+        else if (16 == scale)
+        {
+            REF_ELEMENT_SHIFT = 4; 
+        }
         else
         {
             throw new IllegalStateException("Unknown pointer size: " + scale);


### PR DESCRIPTION
## Motivation
Apache spark benchmarks in renaissance calls into JCTools where it errored because a ptr size of 16 is not valid
## Changes
Change the condition so a ptr size of 16 is valid.